### PR TITLE
FIX #5: report.CRITICAL: Unable to get content (...) for CSS

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -20,7 +20,7 @@
 
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="Lyranetwork_Payzen/css/payzen.css" />
+        <css src="Lyranetwork_Payzen::css/payzen.css" />
     </head>
 
     <body>


### PR DESCRIPTION
Replaced `<css src="...">` handler to a valid one with `Namespace::Module`