### PR TITLE
Updated Payment response to dispatch restore_quote event when payment is not successful

### DIFF
--- a/Controller/Payment/Response.php
+++ b/Controller/Payment/Response.php
@@ -160,7 +160,8 @@ class Response extends \Magento\Framework\App\Action\Action
                 $quote->setIsActive(true)->setReservedOrderId(null);
                 $this->quoteRepository->save($quote);
 
-                $checkout->replaceQuote($quote);
+                $checkout->replaceQuote($quote)->unsLastRealOrderId();
+                $this->_eventManager->dispatch('restore_quote', ['order' => $order, 'quote' => $quote]);
             }
 
             $this->dataHelper->log("Redirecting to cart page for order #{$order->getIncrementId()}.");


### PR DESCRIPTION
Following magento's code (vendor/magento/module-checkout/Model/Session.php:560), when restoring the quote we should dispatch the `restore_quote` event.