### PR TITLE
Redirect to PayZen gateway in vanilla JS

### DIFF
--- a/view/frontend/templates/payment/redirect.phtml
+++ b/view/frontend/templates/payment/redirect.phtml
@@ -24,11 +24,7 @@
 </form>
 
 <script>
-    require([
-        'jquery'
-    ], function($) {
-        $(function() {
-            $('#payzen_payment_form').submit();
-        });
+    document.addEventListener("DOMContentLoaded", function() {
+        document.getElementById("payzen_payment_form").submit();
     });
 </script>


### PR DESCRIPTION
Hello,

This template is causing some random errors like
```
require is not defined
```
and IMO it's better and faster to use a vanilla JS redirection.