### PR TITLE
Allow module to beinstalled when using php 8.1 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "lyranetwork/module-payzen",
 	"description" : "PayZen payment platform integration for Magento 2",
 	"require" : {
-		"php" : "~7"
+		"php" : "~7|~8"
 	},
 	"type" : "magento2-module",
 	"version" : "2.5.12",


### PR DESCRIPTION
Hey!

Noticed there was a release that had changes for PHP 8.x, but the constraint in composer.json was still on 7.
Updated this with the PR.