### PR TITLE
Fix value for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/Model/Api/Rest/Api.php
+++ b/Model/Api/Rest/Api.php
@@ -139,7 +139,7 @@ class Api
 
         // We disable SSL validation for test key because there is a lot of WAMP installations that do not handle certificates well.
         $test_mode = strpos($this->privateKey, 'testpassword_') !== false;
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ! $test_mode);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $test_mode ? 0 : 2);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ! $test_mode);
 
         $raw_response = curl_exec($curl);


### PR DESCRIPTION
Getting this error in production after updating to 2.6.1, which breaks the credit card input fields (they are not shown at all):

    [2022-09-29T13:21:02.947211+00:00] lyra.ERROR: lyra 2.6.1 - Lyranetwork\Lyra\Model\Method\Standard::getRestApiFormToken : Notice: curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead in /var/www/share/client/releases/4/vendor/lyranetwork/module-lyra/Model/Api/Rest/Api.php on line 142 [IP = 127.0.0.1] [] []

From the [docs of `curl_setopt`](https://www.php.net/manual/en/function.curl-setopt):

> 2 to verify that a Common Name field or a Subject Alternate Name field in the SSL peer certificate matches the provided hostname. 0 to not check the names. 1 should not be used. In production environments the value of this option should be kept at 2 (default value).

> Support for value 1 removed in cURL 7.28.1.