### PR TITLE
Update csp_whitelist.xml

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -33,7 +33,7 @@
             <values>
                 <value id="payzen_rest_static_ressources" type="host">https://static.payzen.eu/static/</value>
                 <value id="payzen_krypton_client" type="host">https://api.payzen.eu/static/js/krypton-client/</value>
-                <value id="payzen_font" type="host">https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap/</value>
+                <value id="payzen_font" type="host">https://fonts.googleapis.com/css2?family=Roboto</value>
             </values>
         </policy>
         <policy id="font-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -18,6 +18,7 @@
             <values>
                 <value id="payzen_rest_api" type="host">https://api.payzen.eu/api-payment/</value>
                 <value id="payzen_rest_static_ressources" type="host">https://static.payzen.eu/static/</value>
+                <value id="payzen_krypton_client" type="host">https://api.payzen.eu/static/js/krypton-client/</value>
             </values>
         </policy>
         <policy id="img-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -33,6 +33,7 @@
             <values>
                 <value id="payzen_rest_static_ressources" type="host">https://static.payzen.eu/static/</value>
                 <value id="payzen_krypton_client" type="host">https://api.payzen.eu/static/js/krypton-client/</value>
+                <value id="payzen_font" type="host">https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap/</value>
             </values>
         </policy>
         <policy id="font-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -32,6 +32,7 @@
         <policy id="style-src">
             <values>
                 <value id="payzen_rest_static_ressources" type="host">https://static.payzen.eu/static/</value>
+                <value id="payzen_krypton_client" type="host">https://api.payzen.eu/static/js/krypton-client/</value>
             </values>
         </policy>
         <policy id="font-src">


### PR DESCRIPTION
This should fix the following issues in Magento 2 Checkout in version 2.4.7 or higher, where Magento_Csp module is active by default:

```
Refused to load the script 'https://api.lyra.com/static/js/krypton-client/V4.0/stable/kr-payment-form.min.js' because it violates the following Content Security Policy directive: "script-src ...
```

```
Refused to load the stylesheet 'https://api.lyra.com/static/js/krypton-client/V4.0/ext/classic-reset.css' because it violates the following Content Security Policy directive: "style-src
```