### PR TITLE
#44 Change the string split to manage multibyte. 

### DIFF
--- a/Helper/Checkout.php
+++ b/Helper/Checkout.php
@@ -461,7 +461,7 @@ class Checkout
                 return;
             }
 
-            $arr = str_split($invalidChars);
+            $arr = mb_str_split($invalidChars);
             $invalidChars = '';
             foreach ($arr as $char) {
                 $invalidChars .= '<b>' . $char . '</b> ';

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,9 @@
 	"name" : "lyranetwork/module-payzen",
 	"description" : "PayZen payment platform integration for Magento 2",
 	"require" : {
-		"php" : "~7|~8"
-	},
+		"php" : "~7.4|~8",
+      	"ext-mbstring": "*"
+    },
 	"type" : "magento2-module",
 	"version" : "2.10.0",
 	"license" : "OSL-3.0",


### PR DESCRIPTION
Hello,

See the issue for the problem it resolves : https://github.com/lyra/plugin-magento/issues/47

As the function appeared in PHP-7.4, the composer PHP minimum version must be 7.4 with mbstring extension.

I'll let you decide if this is worth or if you want to do your own implementation of mb_str_split to keep compatibility with older versions of PHP.

Best Regards,
Baptiste
